### PR TITLE
Add basic site account linking

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,3 +77,8 @@ TRANSLATION_ENABLED = (
     os.environ.get('TRANSLATION_ENABLED', 'true').lower() in ['true', '1', 'yes', 'y']
 )
 
+# API settings for linking site accounts
+BOT_API_TOKEN = os.environ.get('BOT_API_TOKEN') or os.getenv('BOT_API_TOKEN') or ''
+SITE_API_URL = os.environ.get('SITE_API_URL') or os.getenv('SITE_API_URL') or ''
+WEBAPP_LINK = os.environ.get('WEBAPP_LINK') or os.getenv('WEBAPP_LINK') or 'https://t.me/ChatAllTelegramBot/linktg'
+

--- a/modules/models/__init__.py
+++ b/modules/models/__init__.py
@@ -11,4 +11,5 @@ from modules.models.user_db import (
     get_user_ids, 
     get_user_language
 )
-from modules.models.image_service import ImageService 
+from modules.models.image_service import ImageService
+from modules.models.site_api import fetch_user, update_balance, link_account

--- a/modules/models/site_api.py
+++ b/modules/models/site_api.py
@@ -1,0 +1,33 @@
+import asyncio
+from typing import Optional, Dict
+import requests
+from config import BOT_API_TOKEN, SITE_API_URL
+
+HEADERS = {"Authorization": f"Bearer {BOT_API_TOKEN}"}
+
+async def _async_request(method: str, endpoint: str, json: Optional[Dict] = None) -> Optional[Dict]:
+    url = f"{SITE_API_URL}{endpoint}"
+    def _send():
+        try:
+            if method == "GET":
+                r = requests.get(url, headers=HEADERS, timeout=10)
+            else:
+                r = requests.post(url, headers=HEADERS, json=json, timeout=10)
+            if r.status_code == 200:
+                return r.json()
+        except Exception as e:
+            print(f"Site API request error: {e}")
+        return None
+    return await asyncio.to_thread(_send)
+
+async def fetch_user(telegram_id: str) -> Optional[Dict]:
+    return await _async_request("GET", f"/api/v1/bot/users/{telegram_id}")
+
+async def update_balance(telegram_id: str, amount: float, typ: str = "credit", description: str = "") -> Optional[Dict]:
+    data = {"amount": amount, "type": typ, "description": description}
+    return await _async_request("POST", f"/api/v1/bot/users/{telegram_id}/balance", data)
+
+async def link_account(user_id: int, telegram_id: str) -> bool:
+    data = {"user_id": user_id, "telegram_id": telegram_id}
+    resp = await _async_request("POST", "/api/v1/bot/link", data)
+    return bool(resp and resp.get("success"))

--- a/modules/user/balance.py
+++ b/modules/user/balance.py
@@ -1,0 +1,34 @@
+import pyrogram
+from pyrogram import filters
+from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo, Message
+from config import WEBAPP_LINK
+from modules.models import user_db
+from modules.models.site_api import fetch_user
+from modules.lang import async_translate_to_lang
+
+async def balance_command(client: pyrogram.Client, message: Message):
+    user_id = message.from_user.id
+    user_lang = user_db.get_user_language(user_id)
+    telegram_id = str(user_id)
+
+    user_data = await fetch_user(telegram_id)
+    if user_data:
+        text = (
+            "ID: {id}\n"
+            "Name: {name}\n"
+            "Email: {email}\n"
+            "Balance: {balance}"
+        ).format(**user_data)
+        text = await async_translate_to_lang(text, user_lang)
+        btn_text = await async_translate_to_lang("Open WebApp", user_lang)
+        keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(btn_text, url=WEBAPP_LINK)]])
+        await message.reply_text(text, reply_markup=keyboard)
+    else:
+        text = await async_translate_to_lang(
+            "Account not linked. Use the button below to link your Telegram account.", user_lang
+        )
+        btn_text = await async_translate_to_lang("Link Account", user_lang)
+        keyboard = InlineKeyboardMarkup(
+            [[InlineKeyboardButton(btn_text, web_app=WebAppInfo(url=WEBAPP_LINK))]]
+        )
+        await message.reply_text(text, reply_markup=keyboard)

--- a/run.py
+++ b/run.py
@@ -47,6 +47,7 @@ import time
 from modules.models.image_service import ImageService
 from modules.user.user_bans_management import ban_user, unban_user, is_user_banned, get_banned_message, get_user_by_id_or_username
 from modules.user.premium_management import add_premium_status, remove_premium_status, is_user_premium, get_premium_status_message, daily_premium_check, get_premium_benefits_message, get_all_premium_users, format_premium_users_list
+from modules.user.balance import balance_command
 import multiprocessing
 import traceback
 
@@ -755,6 +756,12 @@ def create_bot_instance(bot_token, bot_index=1):
             logger.warning(f"Unauthorized user {update.from_user.id} attempted to use invite command")
             await update.reply_text("⛔ У вас нет прав использовать эту команду.")
             await channel_log(bot, update, "/invite", f"Unauthorized access attempt", level="WARNING")
+
+    @advAiBot.on_message(filters.command("balance"))
+    async def balance_cmd(bot, update):
+        if await check_if_banned_and_reply(bot, update):
+            return
+        await balance_command(bot, update)
 
     @advAiBot.on_message(filters.command("uinfo"))
     async def info_commands(bot, update):


### PR DESCRIPTION
## Summary
- configure BOT_API_TOKEN and site API options
- support site API requests
- show user balance via `/balance`
- wire balance command in bot

## Testing
- `python -m py_compile config.py modules/models/site_api.py modules/user/balance.py run.py modules/models/__init__.py`
- `pytest -q` *(fails: TypeError in config)*

------
https://chatgpt.com/codex/tasks/task_b_684d7646179c8325986b614af651bb34