### PR TITLE
Fix invalid URL for balance command webapp

### DIFF
--- a/modules/user/balance.py
+++ b/modules/user/balance.py
@@ -1,6 +1,6 @@
 import pyrogram
 from pyrogram import filters
-from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo, Message
+from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
 from config import WEBAPP_LINK
 from modules.models import user_db
 from modules.models.site_api import fetch_user
@@ -21,7 +21,9 @@ async def balance_command(client: pyrogram.Client, message: Message):
         ).format(**user_data)
         text = await async_translate_to_lang(text, user_lang)
         btn_text = await async_translate_to_lang("Open WebApp", user_lang)
-        keyboard = InlineKeyboardMarkup([[InlineKeyboardButton(btn_text, web_app=WebAppInfo(url=WEBAPP_LINK))]])
+        keyboard = InlineKeyboardMarkup(
+            [[InlineKeyboardButton(btn_text, url=WEBAPP_LINK)]]
+        )
         await message.reply_text(text, reply_markup=keyboard)
     else:
         text = await async_translate_to_lang(
@@ -29,6 +31,6 @@ async def balance_command(client: pyrogram.Client, message: Message):
         )
         btn_text = await async_translate_to_lang("Link Account", user_lang)
         keyboard = InlineKeyboardMarkup(
-            [[InlineKeyboardButton(btn_text, web_app=WebAppInfo(url=WEBAPP_LINK))]]
+            [[InlineKeyboardButton(btn_text, url=WEBAPP_LINK)]]
         )
         await message.reply_text(text, reply_markup=keyboard)


### PR DESCRIPTION
## Summary
- fix invalid webapp link in balance command

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_684d7c595f988325a5a28c2c4be6b03b